### PR TITLE
readme: update helm install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Current version of NUI on K8s deploys:
 ## Getting started
 ```
 helm repo add nats-nui https://nats-nui.github.io/k8s/helm/charts
-helm install nats-nui/nui
+helm install nats-nui nats-nui/nui
 ```
 
 ## Customization


### PR DESCRIPTION
With the previous command helm would fail with the following error:
```bash
$ helm install nats-nui/nui
Error: INSTALLATION FAILED: must either provide a name or specify --generate-name
```

For the lazy people like me having a one liner that just works would be great. Hence with this I'm proposing to give it a default name as `nats-nui` to solve the above error.