### PR TITLE
Adds the ability to provide additional mounts

### DIFF
--- a/helm/charts/nui/templates/statefulset.yaml
+++ b/helm/charts/nui/templates/statefulset.yaml
@@ -63,6 +63,9 @@ spec:
             - name: cli-contexts
               mountPath: /cli-contexts
               readOnly: true
+          {{- with .Values.volumeMounts }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
       volumes:
         - name: creds-volume
           secret:
@@ -73,6 +76,9 @@ spec:
               - key: {{ .key }}
                 path: {{ .path }}
             {{- end }}
+      {{- with .Values.volumes }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
         - name: cli-contexts
           secret:
             optional: true

--- a/helm/charts/nui/values.yaml
+++ b/helm/charts/nui/values.yaml
@@ -76,3 +76,16 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+# Additional volumes on the output Deployment definition.
+volumes: []
+# - name: foo
+#   secret:
+#     secretName: mysecret
+#     optional: false
+
+# Additional volumeMounts on the output Deployment definition.
+volumeMounts: []
+# - name: foo
+#   mountPath: "/etc/foo"
+#   readOnly: true


### PR DESCRIPTION
Allow users to provide custom mounts in the nui container. This allows for additional items like CA chains etc to be mounted into the container.

In my use-case I sign my NATS cluster servers with certs from an internal CA. This change allows me to mount our CA chain into the NUI container which allows NUI to correctly validate the TLS connection.

e.g.
```yaml
volumes:
  - name: ca-bundle
    secret:
      defaultMode: 420
      secretName: custom-ca-chain

volumeMounts:
  - mountPath: /etc/ssl/certs/ca-certificates.crt
    name: ca-bundle
    readOnly: true
    subPath: ca-certs.pem
```